### PR TITLE
Protection against high frequency synchronization pulses

### DIFF
--- a/.settings/com.ti.ccstudio.project.core.prefs
+++ b/.settings/com.ti.ccstudio.project.core.prefs
@@ -1,0 +1,4 @@
+ccsVersionValidationPolicy=warning
+compilerVersionValidationPolicy=flexible
+eclipse.preferences.version=1
+productVersionsValidationPolicy=flexible

--- a/app/board_drivers/hardware_def.h
+++ b/app/board_drivers/hardware_def.h
@@ -83,8 +83,8 @@
 /******************************************************************************
  * GPIO for the debug pin CON9 GPIO0
  *****************************************************************************/
-#define DEBUG_GPIO0_CORE    GPIO_PIN_M_CORE_SELECT // GPIO_PIN_C_CORE_SELECT
-#define DEBUG_GPIO1_CORE    GPIO_PIN_M_CORE_SELECT // GPIO_PIN_C_CORE_SELECT
+#define DEBUG_GPIO0_CORE    GPIO_PIN_C_CORE_SELECT // GPIO_PIN_C_CORE_SELECT
+#define DEBUG_GPIO1_CORE    GPIO_PIN_C_CORE_SELECT // GPIO_PIN_M_CORE_SELECT
 
 #define DEBUG_GPIO0_BASE    GPIO_PORTG_BASE
 #define DEBUG_GPIO0_PIN     GPIO_PIN_6

--- a/app/board_drivers/version.c
+++ b/app/board_drivers/version.c
@@ -23,4 +23,4 @@
 
 volatile firmwares_version_t firmwares_version;
 
-const char * udc_arm_version = "V0.44 2022-06-27";
+const char * udc_arm_version = "V0.44 2022-06-28";

--- a/app/board_drivers/version.c
+++ b/app/board_drivers/version.c
@@ -23,4 +23,4 @@
 
 volatile firmwares_version_t firmwares_version;
 
-const char * udc_arm_version = "V0.44 2022-06-28";
+const char * udc_arm_version = "V0.44 2022-06-30";

--- a/app/board_drivers/version.c
+++ b/app/board_drivers/version.c
@@ -23,4 +23,4 @@
 
 volatile firmwares_version_t firmwares_version;
 
-const char * udc_arm_version = "V0.44 2022-06-23";
+const char * udc_arm_version = "V0.44 2022-06-24";

--- a/app/board_drivers/version.c
+++ b/app/board_drivers/version.c
@@ -23,4 +23,4 @@
 
 volatile firmwares_version_t firmwares_version;
 
-const char * udc_arm_version = "V0.43 2021-12-02";
+const char * udc_arm_version = "V0.44 2022-06-22";

--- a/app/board_drivers/version.c
+++ b/app/board_drivers/version.c
@@ -23,4 +23,4 @@
 
 volatile firmwares_version_t firmwares_version;
 
-const char * udc_arm_version = "V0.44 2022-06-24";
+const char * udc_arm_version = "V0.44 2022-06-27";

--- a/app/board_drivers/version.c
+++ b/app/board_drivers/version.c
@@ -23,4 +23,4 @@
 
 volatile firmwares_version_t firmwares_version;
 
-const char * udc_arm_version = "V0.44 2022-06-22";
+const char * udc_arm_version = "V0.44 2022-06-23";

--- a/app/communication_drivers/bsmp/bsmp_lib.c
+++ b/app/communication_drivers/bsmp/bsmp_lib.c
@@ -2411,7 +2411,7 @@ void bsmp_init(uint8_t server)
     create_bsmp_var(25, server, 4, false, g_ipc_ctom.scope[server].timeslicer.freq_sampling.u8);
     create_bsmp_var(26, server, 4, false, g_ipc_ctom.scope[server].duration.u8);
     create_bsmp_var(27, server, 4, false, g_ipc_ctom.scope[server].p_source.u8);
-    create_bsmp_var(28, server, 1, false, &dummy_u8);   // Reserved common variable
+    create_bsmp_var(28, server, 4, false, g_ipc_ctom.period_sync_pulse.u8);
     create_bsmp_var(29, server, 1, false, &dummy_u8);   // Reserved common variable
     create_bsmp_var(30, server, 1, false, &dummy_u8);   // Reserved common variable
 

--- a/app/communication_drivers/ipc/ipc_lib.h
+++ b/app/communication_drivers/ipc/ipc_lib.h
@@ -138,7 +138,7 @@ typedef volatile struct
     {
         uint8_t     u8[4];
         uint32_t    u32;
-    } counter_sync_period;
+    } period_sync_pulse;
     ps_module_t     ps_module[NUM_MAX_PS_MODULES];
     siggen_t        siggen[NUM_MAX_PS_MODULES];
     wfmref_t        wfmref[NUM_MAX_PS_MODULES];

--- a/app/communication_drivers/ipc/ipc_lib.h
+++ b/app/communication_drivers/ipc/ipc_lib.h
@@ -134,6 +134,11 @@ typedef volatile struct
         uint8_t     u8[4];
         uint32_t    u32;
     } counter_sync_pulse;
+    union
+    {
+        uint8_t     u8[4];
+        uint32_t    u32;
+    } counter_sync_period;
     ps_module_t     ps_module[NUM_MAX_PS_MODULES];
     siggen_t        siggen[NUM_MAX_PS_MODULES];
     wfmref_t        wfmref[NUM_MAX_PS_MODULES];

--- a/app/communication_drivers/ps_modules/fac_2p4s_dcdc/fac_2p4s_dcdc.c
+++ b/app/communication_drivers/ps_modules/fac_2p4s_dcdc/fac_2p4s_dcdc.c
@@ -141,6 +141,11 @@ typedef enum
     Complementary_PS_Itlk
 } soft_interlocks_t;
 
+typedef enum
+{
+    High_Sync_Input_Frequency = 0x00000001
+} alarms_t;
+
 static volatile iib_fac_os_t iib_fac_2p4s_dcdc[8];
 
 static void init_iib_modules();
@@ -281,6 +286,8 @@ static void bsmp_init_server(void)
         create_bsmp_var(79, server, 4, false, iib_fac_2p4s_dcdc[server*2+1].RelativeHumidity.u8);
         create_bsmp_var(80, server, 4, false, iib_fac_2p4s_dcdc[server*2+1].InterlocksRegister.u8);
         create_bsmp_var(81, server, 4, false, iib_fac_2p4s_dcdc[server*2+1].AlarmsRegister.u8);
+
+        create_bsmp_var(82, server, 4, false, g_ipc_ctom.ps_module[0].ps_alarms.u8);
     }
 }
 

--- a/app/communication_drivers/ps_modules/fac_2s_dcdc/fac_2s_dcdc.c
+++ b/app/communication_drivers/ps_modules/fac_2s_dcdc/fac_2s_dcdc.c
@@ -89,6 +89,11 @@ typedef enum
     Load_Feedback_2_Fault
 } soft_interlocks_t;
 
+typedef enum
+{
+    High_Sync_Input_Frequency = 0x00000001
+} alarms_t;
+
 static volatile iib_fac_os_t iib_fac_2s_dcdc[2];
 
 static void init_iib_modules();
@@ -164,6 +169,8 @@ static void bsmp_init_server(void)
     create_bsmp_var(65, 0, 4, false, iib_fac_2s_dcdc[1].RelativeHumidity.u8);
     create_bsmp_var(66, 0, 4, false, iib_fac_2s_dcdc[1].InterlocksRegister.u8);
     create_bsmp_var(67, 0, 4, false, iib_fac_2s_dcdc[1].AlarmsRegister.u8);
+
+    create_bsmp_var(68, 0, 4, false, g_ipc_ctom.ps_module[0].ps_alarms.u8);
 }
 
 /**

--- a/app/communication_drivers/ps_modules/fac_dcdc/fac_dcdc.c
+++ b/app/communication_drivers/ps_modules/fac_dcdc/fac_dcdc.c
@@ -76,6 +76,11 @@ typedef enum
     Load_Feedback_2_Fault,
 } soft_interlocks_t;
 
+typedef enum
+{
+    High_Sync_Input_Frequency = 0x00000001
+} alarms_t;
+
 static volatile iib_fac_os_t iib_fac_os;
 
 static void init_iib_modules();
@@ -134,6 +139,8 @@ static void bsmp_init_server(void)
     create_bsmp_var(50, 0, 4, false, iib_fac_os.RelativeHumidity.u8);
     create_bsmp_var(51, 0, 4, false, iib_fac_os.InterlocksRegister.u8);
     create_bsmp_var(52, 0, 4, false, iib_fac_os.AlarmsRegister.u8);
+
+    create_bsmp_var(53, 0, 4, false, g_ipc_ctom.ps_module[0].ps_alarms.u8);
 }
 
 /**

--- a/app/communication_drivers/ps_modules/fac_dcdc_ema/fac_dcdc_ema.c
+++ b/app/communication_drivers/ps_modules/fac_dcdc_ema/fac_dcdc_ema.c
@@ -73,6 +73,11 @@ typedef enum
     Load_Feedback_Fault,
 } soft_interlocks_t;
 
+typedef enum
+{
+    High_Sync_Input_Frequency = 0x00000001
+} alarms_t;
+
 static volatile iib_fac_os_t iib_fac_os;
 
 static void init_iib_modules();
@@ -128,6 +133,8 @@ static void bsmp_init_server(void)
     create_bsmp_var(48, 0, 4, false, iib_fac_os.RelativeHumidity.u8);
     create_bsmp_var(49, 0, 4, false, iib_fac_os.InterlocksRegister.u8);
     create_bsmp_var(50, 0, 4, false, iib_fac_os.AlarmsRegister.u8);
+
+    create_bsmp_var(51, 0, 4, false, g_ipc_ctom.ps_module[0].ps_alarms.u8);
 }
 
 /**

--- a/app/communication_drivers/ps_modules/fap/fap.c
+++ b/app/communication_drivers/ps_modules/fap/fap.c
@@ -93,6 +93,11 @@ typedef enum
     IGBTs_Current_High_Difference,
 } soft_interlocks_t;
 
+typedef enum
+{
+    High_Sync_Input_Frequency = 0x00000001
+} alarms_t;
+
 static volatile iib_fap_module_t iib_fap;
 
 static void init_iib();
@@ -164,6 +169,8 @@ static void bsmp_init_server(void)
     create_bsmp_var(55, 0, 4, false, iib_fap.RelativeHumidity.u8);
     create_bsmp_var(56, 0, 4, false, iib_fap.InterlocksRegister.u8);
     create_bsmp_var(57, 0, 4, false, iib_fap.AlarmsRegister.u8);
+
+    create_bsmp_var(58, 0, 4, false, g_ipc_ctom.ps_module[0].ps_alarms.u8);
 }
 
 /**

--- a/app/communication_drivers/ps_modules/fap_2p2s/fap_2p2s.c
+++ b/app/communication_drivers/ps_modules/fap_2p2s/fap_2p2s.c
@@ -282,7 +282,10 @@ static void bsmp_init_server(void)
     create_bsmp_var(88, 0, 4, false, iib_fap_2p2s[1].Driver2Current.u8);
     create_bsmp_var(89, 0, 4, false, iib_fap_2p2s[1].TempL.u8);
     create_bsmp_var(90, 0, 4, false, iib_fap_2p2s[1].TempHeatSink.u8);
-    create_bsmp_var(91, 0, 4, false, iib_fap_2p2s[1].GroundLeakage.u8);
+
+    //create_bsmp_var(91, 0, 4, false, iib_fap_2p2s[1].GroundLeakage.u8);
+    create_bsmp_var(91, 0, 4, false, g_ipc_ctom.ps_module[0].ps_alarms.u8);
+
     create_bsmp_var(92, 0, 4, false, iib_fap_2p2s[1].BoardTemperature.u8);
     create_bsmp_var(93, 0, 4, false, iib_fap_2p2s[1].RelativeHumidity.u8);
     create_bsmp_var(94, 0, 4, false, iib_fap_2p2s[1].InterlocksRegister.u8);

--- a/app/communication_drivers/ps_modules/fap_2p2s/fap_2p2s.c
+++ b/app/communication_drivers/ps_modules/fap_2p2s/fap_2p2s.c
@@ -146,6 +146,11 @@ typedef enum
     Complementary_PS_Itlk,
 } soft_interlocks_t;
 
+typedef enum
+{
+    High_Sync_Input_Frequency = 0x00000001
+} alarms_t;
+
 static volatile iib_fap_module_t iib_fap_2p2s[4];
 
 static void init_iib();

--- a/app/communication_drivers/ps_modules/fap_4p/fap_4p.c
+++ b/app/communication_drivers/ps_modules/fap_4p/fap_4p.c
@@ -150,6 +150,11 @@ typedef enum
     IGBTs_Current_High_Difference
 } soft_interlocks_t;
 
+typedef enum
+{
+    High_Sync_Input_Frequency = 0x00000001
+} alarms_t;
+
 static volatile iib_fap_module_t iib_fap_4p[4];
 
 static void init_iib();
@@ -314,6 +319,9 @@ static void bsmp_init_server(void)
     create_bsmp_var(119, 0, 4, false, iib_fap_4p[3].RelativeHumidity.u8);
     create_bsmp_var(120, 0, 4, false, iib_fap_4p[3].InterlocksRegister.u8);
     create_bsmp_var(121, 0, 4, false, iib_fap_4p[3].AlarmsRegister.u8);
+
+    create_bsmp_var(122, 0, 4, false, g_ipc_ctom.ps_module[0].ps_alarms.u8);
+
 }
 
 /**

--- a/app/communication_drivers/ps_modules/fbp/fbp.c
+++ b/app/communication_drivers/ps_modules/fbp/fbp.c
@@ -83,6 +83,11 @@ typedef enum
     Heatsink_Overtemperature
 } soft_interlocks_t;
 
+typedef enum
+{
+    High_Sync_Input_Frequency = 0x00000001
+} alarms_t;
+
 /**
 * @brief Initialize ADCP Channels.
 *

--- a/app/communication_drivers/ps_modules/fbp/fbp.c
+++ b/app/communication_drivers/ps_modules/fbp/fbp.c
@@ -220,6 +220,11 @@ static void bsmp_init_server(void)
         create_bsmp_var(67, server, 4, false, PS2_LOAD_CURRENT.u8);
         create_bsmp_var(68, server, 4, false, PS3_LOAD_CURRENT.u8);
         create_bsmp_var(69, server, 4, false, PS4_LOAD_CURRENT.u8);
+
+        create_bsmp_var(70, server, 4, false, g_ipc_ctom.ps_module[PS1_ID].ps_alarms.u8);
+        create_bsmp_var(71, server, 4, false, g_ipc_ctom.ps_module[PS2_ID].ps_alarms.u8);
+        create_bsmp_var(72, server, 4, false, g_ipc_ctom.ps_module[PS3_ID].ps_alarms.u8);
+        create_bsmp_var(73, server, 4, false, g_ipc_ctom.ps_module[PS4_ID].ps_alarms.u8);
     }
 
 }

--- a/app/communication_drivers/ps_modules/fbp/fbp.c
+++ b/app/communication_drivers/ps_modules/fbp/fbp.c
@@ -155,6 +155,7 @@ static void bsmp_init_server(void)
     create_bsmp_var(35, PS1_ID, 4, false, PS1_DCLINK_VOLTAGE.u8);
     create_bsmp_var(36, PS1_ID, 4, false, PS1_TEMPERATURE.u8);
     create_bsmp_var(37, PS1_ID, 4, false, PS1_DUTY_CYCLE.u8);
+    create_bsmp_var(38, PS1_ID, 4, false, g_ipc_ctom.ps_module[PS1_ID].ps_alarms.u8);
 
     create_bsmp_var(31, PS2_ID, 4, false, g_ipc_ctom.ps_module[PS2_ID].ps_soft_interlock.u8);
     create_bsmp_var(32, PS2_ID, 4, false, g_ipc_ctom.ps_module[PS2_ID].ps_hard_interlock.u8);
@@ -163,6 +164,7 @@ static void bsmp_init_server(void)
     create_bsmp_var(35, PS2_ID, 4, false, PS2_DCLINK_VOLTAGE.u8);
     create_bsmp_var(36, PS2_ID, 4, false, PS2_TEMPERATURE.u8);
     create_bsmp_var(37, PS2_ID, 4, false, PS2_DUTY_CYCLE.u8);
+    create_bsmp_var(38, PS2_ID, 4, false, g_ipc_ctom.ps_module[PS2_ID].ps_alarms.u8);
 
     create_bsmp_var(31, PS3_ID, 4, false, g_ipc_ctom.ps_module[PS3_ID].ps_soft_interlock.u8);
     create_bsmp_var(32, PS3_ID, 4, false, g_ipc_ctom.ps_module[PS3_ID].ps_hard_interlock.u8);
@@ -171,6 +173,7 @@ static void bsmp_init_server(void)
     create_bsmp_var(35, PS3_ID, 4, false, PS3_DCLINK_VOLTAGE.u8);
     create_bsmp_var(36, PS3_ID, 4, false, PS3_TEMPERATURE.u8);
     create_bsmp_var(37, PS3_ID, 4, false, PS3_DUTY_CYCLE.u8);
+    create_bsmp_var(38, PS3_ID, 4, false, g_ipc_ctom.ps_module[PS3_ID].ps_alarms.u8);
 
     create_bsmp_var(31, PS4_ID, 4, false, g_ipc_ctom.ps_module[PS4_ID].ps_soft_interlock.u8);
     create_bsmp_var(32, PS4_ID, 4, false, g_ipc_ctom.ps_module[PS4_ID].ps_hard_interlock.u8);
@@ -179,10 +182,10 @@ static void bsmp_init_server(void)
     create_bsmp_var(35, PS4_ID, 4, false, PS4_DCLINK_VOLTAGE.u8);
     create_bsmp_var(36, PS4_ID, 4, false, PS4_TEMPERATURE.u8);
     create_bsmp_var(37, PS4_ID, 4, false, PS4_DUTY_CYCLE.u8);
+    create_bsmp_var(38, PS4_ID, 4, false, g_ipc_ctom.ps_module[PS4_ID].ps_alarms.u8);
 
     for(server = 0; server < NUM_MAX_PS_MODULES; server++)
     {
-        create_bsmp_var(38, server, 1, false, &dummy_u8);
         create_bsmp_var(39, server, 1, false, &dummy_u8);
         create_bsmp_var(40, server, 1, false, &dummy_u8);
         create_bsmp_var(41, server, 1, false, &dummy_u8);

--- a/app/communication_drivers/ps_modules/ps_modules.h
+++ b/app/communication_drivers/ps_modules/ps_modules.h
@@ -131,6 +131,11 @@ typedef struct
         volatile uint8_t    u8[4];
     } ps_soft_interlock;
 
+    union {
+            volatile uint32_t   u32;
+            volatile uint8_t    u8[4];
+    } ps_alarms;
+
     void            (*turn_on)(void);
     void            (*turn_off)(void);
     void            (*isr_soft_interlock)(void);


### PR DESCRIPTION
Intentionally or not, synchronization pulses with high frequency blocked the execution of controller ISR on DSP.

The implemented solution disables the ISR responsible for sync pulses inside itself and re-enables it inside the controller ISR. This way, only one ISR for sync pulses is executed at each controller period.

Also, a counter for the number of ISR controller cycles executed between two sync pulses was included in order to create an alarm that informs that the controller is receiving an unexpected high frequency at its sync input.