### PR TITLE
Remove temperature readings from FBP ps model.

### DIFF
--- a/app/communication_drivers/parameters/system/system.c
+++ b/app/communication_drivers/parameters/system/system.c
@@ -112,7 +112,7 @@ void init_system(void)
 
 	init_control_framework(&g_controller_mtoc);
 
-	init_i2c_offboard_external_devices();
+	//init_i2c_offboard_external_devices();
 
 	flash_mem_init();
 

--- a/app/communication_drivers/system_task/system_task.c
+++ b/app/communication_drivers/system_task/system_task.c
@@ -253,7 +253,7 @@ void TaskCheck(void)
 
 		// TODO: Fix it
 		//switch(g_ipc_mtoc[0].PSModule.Model.u16)
-		switch(g_ipc_mtoc.ps_module[g_current_ps_id].ps_status.bit.model)
+		switch(g_ipc_mtoc.ps_module[0].ps_status.bit.model)
 		{
 			case FBP:
 			    power_supply_1_temp_read();

--- a/app/communication_drivers/timer/timer.c
+++ b/app/communication_drivers/timer/timer.c
@@ -70,7 +70,7 @@ void isr_global_timer(void)
 	{
 		time = 0;
 		TaskSetNew(SAMPLE_RTC);
-		TaskSetNew(POWER_TEMP_SAMPLE);
+		//TaskSetNew(POWER_TEMP_SAMPLE);
 		#if HARDWARE_VERSION == 0x21
 		    TaskSetNew(LED_STATUS);
 			#endif


### PR DESCRIPTION
A bug was found in the I2C driver used on these readings, which brings ARM core to a infinte loop.